### PR TITLE
for homework 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ class Setup(object):
         # ...
         # powers_of_x[i] =  b.G1 * tau**i = powers_of_x[i - 1] * tau
         # TODO: generate powers_of_x
+        powers_of_x = [b.multiply(b.G1, tau**i) for i in range(powers)]
         # reference: https://github.com/sec-bit/learning-zkp/blob/master/plonk-intro-cn/5-plonk-polycom.md
 
         print("Generated G1 side, X^1 point: {}".format(powers_of_x[1]))


### PR DESCRIPTION
➜  baby-plonk git:(2d2b53f) poetry run python test.py
```
The currently activated Python version 3.12.2 is not supported by the project (>=3.9,<3.12).
Trying to find and use a compatible version.
Using python3.9 (3.9.16)
Random number tau:  55
Beginning prover test
Start to generate structured reference string
Generated G1 side, X^1 point: (3527795369844195554172197723159831261105130023402705803501075808490245373308, 5885873591116991251877003083163610233473425240097428011489248730437747759621)
Generated G2 side, X^1 point: ((18748086621274514836260249004666748860906308799513497103270080075855784879247, 14543264044668454395400072712721639610640004432822281312874252470820395206772), (17201213690169614647750705911426981957681753561715146541409384530521142575670, 12953916560658458950977114780511514669385063505981082756160491268449665391564))
Finished to generate structured reference string
Permutation accumulator polynomial successfully generated
Generated the quotient polynomial
Generated final quotient witness polynomials
Prover test success
Beginning verifier test
Done KZG10 commitment check for a_eval polynomial
Done KZG10 commitment check for b_eval polynomial
Done KZG10 commitment check for c_eval polynomial
Done KZG10 commitment check for z_eval polynomial
Done KZG10 commitment check for zw_eval polynomial
Done KZG10 commitment check for t_eval polynomial
Done KZG10 commitment check for ql_eval polynomial
Done KZG10 commitment check for qr_eval polynomial
Done KZG10 commitment check for qm_eval polynomial
Done KZG10 commitment check for qo_eval polynomial
Done KZG10 commitment check for qc_eval polynomial
Done KZG10 commitment check for s1_eval polynomial
Done KZG10 commitment check for s2_eval polynomial
Done KZG10 commitment check for s3_eval polynomial
Done equation check for all constraints
Verifier test success
```