### PR TITLE
for homework 2

### DIFF
--- a/prover.py
+++ b/prover.py
@@ -241,6 +241,7 @@ class Prover:
         # reference: https://github.com/sec-bit/learning-zkp/blob/master/plonk-intro-cn/4-plonk-constraints.md
         gate_constraints_coeff = (
             # TODO: your code
+            (QL_coeff * A_coeff) + (QR_coeff * B_coeff) + (QM_coeff * A_coeff * B_coeff) + (QO_coeff * C_coeff) + QC_coeff + PI_coeff
         )
 
         normal_roots = Polynomial(
@@ -269,6 +270,27 @@ class Prover:
         # reference: https://github.com/sec-bit/learning-zkp/blob/master/plonk-intro-cn/3-plonk-permutation.md
         permutation_grand_product_coeff = (
             # TODO: your code
+            # NOTE: the implementation of id(x) is `Cell.label()`:
+            #
+            #     ```
+            #     # Outputs the label (an inner-field element) representing a given
+            #     # (column, row) pair. Expects section = 1 for left, 2 right, 3 output
+            #     def label(self, group_order: int) -> Scalar:
+            #         assert self.row < group_order
+            #         return Scalar.roots_of_unity(group_order)[self.row] * self.column.value
+            #     ```
+            #
+            # NOTE: the results of `Z(wX) g(X) - Z(X) f(X)` and `z(X) f(X) - z(wX) g(X)` are different.
+
+            Z_coeff
+            * (A_coeff + (Polynomial([Scalar.roots_of_unity(group_order)[row] * 1 for row in range(group_order)], Basis.LAGRANGE).ifft()  * self.beta) + self.gamma)
+            * (B_coeff + (Polynomial([Scalar.roots_of_unity(group_order)[row] * 2 for row in range(group_order)], Basis.LAGRANGE).ifft()  * self.beta) + self.gamma)
+            * (C_coeff + (Polynomial([Scalar.roots_of_unity(group_order)[row] * 3 for row in range(group_order)], Basis.LAGRANGE).ifft()  * self.beta) + self.gamma)
+
+            - ZW_coeff
+            * (A_coeff + (S1_coeff * self.beta) + self.gamma)
+            * (B_coeff + (S2_coeff * self.beta) + self.gamma)
+            * (C_coeff + (S3_coeff * self.beta) + self.gamma)
         )
 
         permutation_first_row_coeff = (Z_coeff - Scalar(1)) * L0_coeff


### PR DESCRIPTION
➜  baby-plonk git:(ce8999f) ✗ poetry run python test.py
```
The currently activated Python version 3.12.2 is not supported by the project (>=3.9,<3.12).
Trying to find and use a compatible version.
Using python3.9 (3.9.16)
Random number tau:  94
Beginning prover test
Start to generate structured reference string
Generated G1 side, X^1 point: (2519871291166183212321992059388191152929383296751560813326833213080466336658, 8881054332348565639330298640726057905794524196751570470630692445877881727944)
Generated G2 side, X^1 point: ((6461681695433881648225031317851748954880471786706985063440836815955874921685, 19453623254856546733274069783025441391725815064356083182451651247262066136902), (2708331047077905669510533614881599538214073657629149913868689543506862571958, 8181593446329764650105092347137238911828711909924512910433995545061963659315))
Finished to generate structured reference string
Permutation accumulator polynomial successfully generated
Generated the quotient polynomial
Generated final quotient witness polynomials
Prover test success
Beginning verifier test
Done KZG10 commitment check for a_eval polynomial
Done KZG10 commitment check for b_eval polynomial
Done KZG10 commitment check for c_eval polynomial
Done KZG10 commitment check for z_eval polynomial
Done KZG10 commitment check for zw_eval polynomial
Done KZG10 commitment check for t_eval polynomial
Done KZG10 commitment check for ql_eval polynomial
Done KZG10 commitment check for qr_eval polynomial
Done KZG10 commitment check for qm_eval polynomial
Done KZG10 commitment check for qo_eval polynomial
Done KZG10 commitment check for qc_eval polynomial
Done KZG10 commitment check for s1_eval polynomial
Done KZG10 commitment check for s2_eval polynomial
Done KZG10 commitment check for s3_eval polynomial
Done equation check for all constraints
Verifier test success
```