### PR TITLE
for homework 3

### DIFF
--- a/verifier.py
+++ b/verifier.py
@@ -91,15 +91,22 @@ class VerificationKey:
         # reference: https://github.com/sec-bit/learning-zkp/blob/master/plonk-intro-cn/4-plonk-constraints.md
         f_eval = (
             # TODO: your code
+            (a_eval + 1 * beta * zeta + gamma)
+            * (b_eval + 2 * beta * zeta + gamma)
+            * (c_eval + 3 * beta * zeta + gamma)
         )
         g_eval = (
             # TODO: your code
+            (a_eval + s1_eval * beta + gamma)
+            * (b_eval + s2_eval * beta + gamma)
+            * (c_eval + s3_eval * beta + gamma)
         )
         permutation_grand_product_eval = z_eval * f_eval - zw_eval * g_eval
 
         # evaluate gate constraints polynomial at zeta
         gate_constraints_eval = (
             # TODO: your code
+            ql_eval * a_eval + qr_eval * b_eval + qm_eval * a_eval * b_eval + qo_eval * c_eval + qc_eval + PI_ev
         )
 
         permutation_first_row_eval = L0_ev * (z_eval - 1)


### PR DESCRIPTION
➜  baby-plonk git:(0280cb4) ✗ poetry run python test.py
```
The currently activated Python version 3.12.2 is not supported by the project (>=3.9,<3.12).
Trying to find and use a compatible version.
Using python3.9 (3.9.16)
Random number tau:  20
Beginning prover test
Start to generate structured reference string
Generated G1 side, X^1 point: (18947110137775984544896515092961257947872750783784269176923414004072777296602, 12292085037693291586083644966434670280746730626861846747147579999202931064992)
Generated G2 side, X^1 point: ((6584456886510528562221720296624431746328412524156386210384049614268366928061, 13505823173380835868587575884635704883599421098297400455389802021584825778173), (5101591763860554569577488373372350852473588323930260132008193335489992486594, 17537837094362477976396927178636162167615173290927363003743794104386247847571))
Finished to generate structured reference string
Permutation accumulator polynomial successfully generated
Generated the quotient polynomial
Generated final quotient witness polynomials
Prover test success
Beginning verifier test
Done KZG10 commitment check for a_eval polynomial
Done KZG10 commitment check for b_eval polynomial
Done KZG10 commitment check for c_eval polynomial
Done KZG10 commitment check for z_eval polynomial
Done KZG10 commitment check for zw_eval polynomial
Done KZG10 commitment check for t_eval polynomial
Done KZG10 commitment check for ql_eval polynomial
Done KZG10 commitment check for qr_eval polynomial
Done KZG10 commitment check for qm_eval polynomial
Done KZG10 commitment check for qo_eval polynomial
Done KZG10 commitment check for qc_eval polynomial
Done KZG10 commitment check for s1_eval polynomial
Done KZG10 commitment check for s2_eval polynomial
Done KZG10 commitment check for s3_eval polynomial
Done equation check for all constraints
Verifier test success
```